### PR TITLE
Fix audioplayer on smaller screen

### DIFF
--- a/layouts/partials/audioplayer.html
+++ b/layouts/partials/audioplayer.html
@@ -9,7 +9,7 @@
     <img class="block w-full" src="{{ . }}" alt="Cover art for {{ $.title }}">
   {{ end }}
 
-  <div class="flex flex-wrap items-center justify-between p-4">
+  <div class="flex flex-nowrap items-center justify-between p-4">
 
     <div class="hidden current-time md:inline-block text-grey">
       <span class="amplitude-current-minutes" amplitude-main-current-seconds="true"></span>:
@@ -18,7 +18,7 @@
     {{ if $multiple }}
       <div class="amplitude-prev w-4 cursor-pointer" id="previous">{{ partialCached "svg/step-backward-solid.svg" "backward" }}</div>
     {{ end }}
-    <div class="flex flex-wrap items-center justify-between">
+    <div class="flex flex-wrap items-center justify-center sm:justify-between">
       <div class="song-title w-100 py-1 md:py-0 text-grey-light">
         <span data-amplitude-song-info="copy"></span><span class="italic" data-amplitude-song-info="title"></span>
       </div>


### PR DESCRIPTION
For smaller screen we move the play/pause button below title and centered.

![Capture d’écran, le 2021-12-13 à 10 06 03](https://user-images.githubusercontent.com/1480503/145836732-c80ae6bc-f56f-46ff-ac65-a73f187d012a.png)

Fixes #163